### PR TITLE
Only syncTimestamp if options.timestamp is defined

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
         } else {
           grunt.verbose.writeln('Copying ' + chalk.cyan(src) + ' -> ' + chalk.cyan(dest));
           grunt.file.copy(src, dest, copyOptions);
-          syncTimestamp(src, dest);
+          if (options.timestamp) syncTimestamp(src, dest);
           if (options.mode !== false) {
             fs.chmodSync(dest, (options.mode === true) ? fs.lstatSync(src).mode : options.mode);
           }


### PR DESCRIPTION
Make all instances of syncTimestamps respect the options.timestamp.
